### PR TITLE
[Editorial] Fix some HTML errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset='utf-8'>
+    <meta charset="utf-8">
     <title>Web Media APIs 2017</title>
-    <script 
-     src='https://www.w3.org/Tools/respec/respec-w3c-common' 
-     class='remove'></script>
-    <script class='remove'>
+    <script
+     src="https://www.w3.org/Tools/respec/respec-w3c-common"
+     class="remove"></script>
+    <script class="remove">
       var respecConfig = {
         specStatus: "CG-DRAFT",
         editors: [{
@@ -24,7 +24,7 @@
     </script>
   </head>
   <body>
-    <section id='abstract'>
+    <section id="abstract">
       <p>
 This specification defines the Web APIs that should be included in device implementations to support media web apps in 2017. This specification should be updated at least annually to keep pace with the evolving Web platform. This specification is comprised of references to existing specifications in W3C and other specification groups. The target devices will include any device that runs a modern HTML user agent, including televisions, game machines, set-top boxes, mobile devices and personal computers.
       </p>
@@ -32,7 +32,7 @@ This specification defines the Web APIs that should be included in device implem
 The goal of this Web Media API Community Group specification is to transition to the W3C Recommendation Track for standards development.
       </p>
     </section>
-    <section id='sotd'>
+    <section id="sotd">
     </section>
     <section>
       <h2>Introduction</h2>
@@ -49,10 +49,8 @@ The goal of this Web Media API Community Group specification is to transition to
       <p>Devices MUST support the following specifications:</p>
         <ul>
         <li>HTML 5.1 [[!HTML51]]</li>
-	<li>ECMAScript Language Specification, Edition 5.1 [[!ECMASCRIPT-5.1]]</li>
-<p class="ednote">
-ECMA published ECMAScript 6 [[ECMASCRIPT-6.0]] in 2015 & ECMAScript 7 [[ECMASCRIPT]] in 2016, but I don't know if they're widely implemented, yet.
-<p>
+        <li>ECMAScript Language Specification, Edition 5.1 [[!ECMASCRIPT-5.1]]<p class="ednote">ECMA published ECMAScript 6 [[ECMASCRIPT-6.0]] in 2015 &amp; ECMAScript 7 [[ECMASCRIPT]] in 2016, but I don't know if they're widely implemented, yet.</p>
+        </li>
         </ul>
     </section>
     <section>
@@ -99,10 +97,8 @@ The following list of widely deployed and interoperable CSS specs is taken direc
         <ul>
         <li> Encrypted Media Extensions [[!ENCRYPTED-MEDIA]]</li>
         <li> Media Source Extensions [[!MEDIA-SOURCE]]</li>
-<p class="ednote">
-The ISO Common Encryption [[!eme-stream-mp4]] reference may need to be updated for MPEG CMAF.
-<p>
-	<li>ISO Common Encryption ('cenc') Protection Scheme for ISO Base Media File Format Stream Format [[!eme-stream-mp4]]</li>
+        <li>ISO Common Encryption ('cenc') Protection Scheme for ISO Base Media File Format Stream Format [[!eme-stream-mp4]]<p class="ednote">The ISO Common Encryption [[!eme-stream-mp4]] reference may need to be updated for MPEG CMAF.</p>
+        </li>
         </ul>
       <p>Devices SHOULD support the following specifications:</p>
         <ul>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
           companyURL: "http://www.comcast.com"
         }],
         processVersion: 2015,
-        edDraftURI: "http://w3c.github.io/webmediaapi",
+        edDraftURI: "https://w3c.github.io/webmediaapi",
         shortName: "dahut",
         wg: "Web Media API Community Group",
         wgURI: "https://www.w3.org/community/webmediaapi/",


### PR DESCRIPTION
Only `<li>` are allowed with `<ul>`, so needed to move `<p>` elements around to make the HTML valid.
Escaped `&`
Also pointlessly changed all the `'` to `"` for consistency across the document.