### PR TITLE
Re-add Replace editors note with issue about ES version

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,8 +61,7 @@ The goal of this Web Media API Community Group specification is to transition to
       <p>Devices MUST support the following specifications:</p>
         <ul>
         <li>HTML 5.1 [[!HTML51]]</li>
-        <li>ECMAScript Language Specification, Edition 5.1 [[!ECMASCRIPT-5.1]]<p class="ednote">ECMA published ECMAScript 6 [[ECMASCRIPT-6.0]] in 2015 &amp; ECMAScript 7 [[ECMASCRIPT]] in 2016, but I don't know if they're widely implemented, yet.</p>
-        </li>
+        <li>ECMAScript Language Specification, Edition 5.1 [[!ECMASCRIPT-5.1]]<p class="issue">ECMA published ECMAScript 6 [[ECMASCRIPT-6.0]] in 2015, and ECMAScript 7 [[ECMASCRIPT]] in 2016. See <a href="https://github.com/w3c/webmediaapi/issues/20">Issue 20</a> for discussion on which version we should reference.</p></li>
         </ul>
     </section>
     <section>


### PR DESCRIPTION
Seems I managed to remove this in another commit just minutes after merging #36. Apologies.

Merging immediately as content is identical to #36 and editorial only.