### PR TITLE
[Editorial] Change another 'support' to 'be conforming implementations of'

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@ The goal of this Web Media API Community Group specification is to transition to
         <li>HTML 5.1 [[!HTML51]]</li>
         <li>ECMAScript Language Specification, Edition 5.1 [[!ECMASCRIPT-5.1]]</li>
         </ul>
-      <p>Devices SHOULD support the following specifications:</p>
+      <p>Devices SHOULD be conforming implementations of the following specifications:</p>
         <ul>
         <li>ECMAScript Language Specification, Edition 6 [[!ECMASCRIPT-6.0]]</li>
         </ul>


### PR DESCRIPTION
There was a missed 'support' which should have been changed to 'be conforming implementations of' as per #58.