### PR TITLE
Issue #27 - add text about polyfills, UA version numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,12 +50,14 @@ The goal of this Web Media API Community Group specification is to transition to
       <h2>Introduction</h2>
 <ol class="ednote" title="Notes on v1 draft specification:">
 <li>The approach taken in this draft is to only include specifications that are of particular significance to application programmers, but not include all the specifications cited by those included specifications. For example, IETF RFC 1345, Character Mnemonics and Character Sets [[RFC1345]] is required by the HTML5 spec included here, but is not included as a required spec here. </li>
-<li>Required APIs are meant to be available in 2016 in a usable form in the four major web user agent code bases. This is to enable the APIs to be delivered in consumer products in 2017</li>
-<li>Recommended APIs represent desired functionality that is not yet implemented widely enough to be Required.</li>
 </ol>
     </section>
     <section>
       <h2>Required specifications</h2>
+        <p>Required APIs are meant to be available in 2016 in a usable form in the four major web user agent code bases. This is to enable the APIs to be delivered in consumer products in 2017.</p>
+        <p class="note">WAVE makes no requirements around explicit version number or release date for any client code bases - any code base that passes the WAVE HATF test suite is compliant.</p>
+        <p>Recommended APIs represent desired functionality that is not yet implemented widely enough to be Required.</p>
+        <p>Where an API is made available by a <quot>polyfill</quot>, responsibility for providing the polyfill lies with the developer.</p>
     <section>
       <h3>HTML core specifications</h3>
       <p>Devices MUST be conforming implementations of the following specifications:</p>


### PR DESCRIPTION
Implements consensus described in https://github.com/w3c/webmediaapi/issues/27#issuecomment-291909386.

I have moved the existing text which covered points (1) and (3) to Section 2, and added text covering points (2) and (4).