### PR TITLE
Fix #15 - add undated refs to WHATWG HTML for channel- and web-messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,22 @@
         shortName: "dahut",
         wg: "Web Media API Community Group",
         wgURI: "https://www.w3.org/community/webmediaapi/",
+        localBiblio: {
+          "WEB-MESSAGING": {
+            authors: ["Anne van Kesteren", "Domenic Denicola", "Ian Hickson", "Philip Jägenstedt", "Simon Pieters"],
+            title: "HTML Standard: Cross-document messaging",
+            href: "https://html.spec.whatwg.org/multipage/comms.html#web-messaging",
+            status: "Living Standard",
+            publisher: "WHATWG",
+          },
+          "CHANNEL-MESSAGING": {
+            authors: ["Anne van Kesteren", "Domenic Denicola", "Ian Hickson", "Philip Jägenstedt", "Simon Pieters"],
+            title: "HTML Standard: Channel messaging",
+            href: "https://html.spec.whatwg.org/multipage/comms.html#channel-messaging",
+            status: "Living Standard",
+            publisher: "WHATWG",
+          }
+        }
       };
     </script>
   </head>
@@ -175,6 +191,8 @@ The following list of widely deployed and interoperable CSS specs is taken direc
         <li> Web Storage [[!WEBSTORAGE]]</li>
         <li> Web Workers [[!WORKERS]]</li>
         <li> Indexed Database API [[!INDEXEDDB]]</li>
+        <li> Cross-document messaging [[!WEB-MESSAGING]]</li>
+        <li> Channel messaging [[!CHANNEL-MESSAGING]]</li>
         </ul>
     </section>
     </section>


### PR DESCRIPTION
In time we should probably transition to specref entries, but the quickest thing to do was add `localBiblio` entries.