### PR TITLE
Fix ReSpec issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
           company: "British Broadcasting Corporation",
           companyURL: "http://www.bbc.co.uk/rd"
         }],
-        processVersion: 2015,
+        processVersion: 2017,
         edDraftURI: "https://w3c.github.io/webmediaapi",
         shortName: "dahut",
         wg: "Web Media API Community Group",

--- a/index.html
+++ b/index.html
@@ -46,6 +46,13 @@
             href: "https://html.spec.whatwg.org/multipage/comms.html#channel-messaging",
             status: "Living Standard",
             publisher: "WHATWG",
+          },
+          "INBANDTRACKS": {
+            authors: ["Silvia Pfeiffer", "Bob Lund"],
+            title: "Sourcing In-band Media Resource Tracks from Media Containers into HTML",
+            href: "http://dev.w3.org/html5/html-sourcing-inband-tracks/",
+            status: "Unofficial Draft",
+            publisher: "W3C",
           }
         }
       };

--- a/index.html
+++ b/index.html
@@ -46,13 +46,6 @@
             href: "https://html.spec.whatwg.org/multipage/comms.html#channel-messaging",
             status: "Living Standard",
             publisher: "WHATWG",
-          },
-          "INBANDTRACKS": {
-            authors: ["Silvia Pfeiffer", "Bob Lund"],
-            title: "Sourcing In-band Media Resource Tracks from Media Containers into HTML",
-            href: "http://dev.w3.org/html5/html-sourcing-inband-tracks/",
-            status: "Unofficial Draft",
-            publisher: "W3C",
           }
         }
       };


### PR DESCRIPTION
From https://github.com/w3c/webmediaapi/pull/76#issuecomment-311661884:

Fix item 1 by changing `processVersion`.
Temporary fix for item 2. This needs a ReSpec change to be fixed properly.