### PR TITLE
Implement #69: Include APIs required and recommended for PWA support

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,6 +178,7 @@
           </li>
           <li> Cross-document messaging [[!WEB-MESSAGING]]</li>
           <li> Channel messaging [[!CHANNEL-MESSAGING]]</li>
+          <li> Web Notifications [[!notifications-20151022]]</li>
         </ul>
       </section>
     </section>
@@ -195,6 +196,7 @@
         <ul>
           <li> Sourcing In-band Media Resource Tracks from Media Containers into HTML [[INBANDTRACKS]]</li>
           <li> Media Fragments URI 1.0 (basic) [[media-frags]]</li>
+          <li> Media Session Standard [[MEDIASESSION]]</li>
         </ul>
       </section>
       <section>
@@ -207,6 +209,13 @@
         <h3>Networking specifications</h3>
         <ul>
           <li> Server-Sent Events [[EVENTSOURCE]]</li>
+        </ul>
+      </section>
+      <section>
+        <h3> Other web specifications</h3>
+        <ul>
+          <li> Web App Manifest [[appmanifest]]</li>
+          <li> Service Workers 1 [[service-workers-1]]</li>
         </ul>
       </section>
     </section>


### PR DESCRIPTION
Implements https://github.com/w3c/webmediaapi/issues/69#issuecomment-305136736.

Caniuse says Web Notifications are supported across the four major codebases (http://caniuse.com/#feat=notifications), so I have included that in the _Required_ section.

Media Session, Web App Manifest and Service Workers are added as aspirational APIs.

I have not included Background Fetch in this PR for the reason stated in https://github.com/w3c/webmediaapi/issues/69#issuecomment-312207259, but this could be added.