### PR TITLE
Remove Thasso from editors list

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,12 +16,6 @@
           companyURL: "https://www.bbc.co.uk/rd"
         },
         {
-          name: "Thasso Griebel",
-          url: "mailto:thasso.griebel@castlabs.com",
-          company: "CastLabs GmbH",
-          companyURL: "https://www.castlabs.com"
-        },
-        {
           name: "Mark Vickers",
           url: "mailto:mark_vickers@comcast.com",
           company: "Comcast",


### PR DESCRIPTION
Thasso edits the Developer Guidelines spec, not the API specification.