### PR TITLE
Fix #70 - change opening statement around code base support of APIs at publication time

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
       <h2>Web Media APIs currently supported on all platforms</h2>
       <section>
         <h2>Introduction</h2>
-        <p>This section defines the Web APIs to support media web apps that are supported across all four of the most widely used user agent code bases (though there are no requirements around explicit version number or release date for any client code bases). We encourage manufacturers to develop products that support these APIs.</p>
+        <p>This section defines the Web APIs to support media web apps that are supported across all four of the most widely used user agent code bases at the time of publication (though there are no requirements around explicit version number or release date for any client code bases). We encourage manufacturers to develop products that support the APIs in the most recent version of this specification.</p>
         <p>The approach taken in this draft is to only include specifications that are of particular significance to application programmers, but not include all the specifications cited by those included specifications. For example, IETF RFC 1345, Character Mnemonics and Character Sets [[RFC1345]] is required by the HTML5 spec included here, but is not included as a required specification here.</p>
         <section>
           <h3>APIs not widely implemented across all web platforms</h3>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
   </head>
   <body>
     <section id="abstract">
-      <p>This specification defines the Web APIs that should be included in device implementations to support media web apps in 2017. This specification should be updated at least annually to keep pace with the evolving Web platform. This specification is comprised of references to existing specifications in W3C and other specification groups. The target devices will include any device that runs a modern HTML user agent, including televisions, game machines, set-top boxes, mobile devices and personal computers.</p>
+      <p>This specification defines the Web APIs to support media web apps that are supported across all four of the most widely used user agent code bases at the time of publication. This specification should be updated at least annually to keep pace with the evolving Web platform. We encourage manufacturers to develop products that support the APIs in the most recent version of Web Media API Snapshot. This specification is comprised of references to existing specifications in W3C and other specification groups. The target devices will include any device that runs a modern HTML user agent, including televisions, game machines, set-top boxes, mobile devices and personal computers.</p>
       <p>The goal of this Web Media API Community Group specification is to transition to the W3C Recommendation Track for standards development.</p>
     </section>
     <section id="sotd">
@@ -65,7 +65,7 @@
       <h2>Web Media APIs currently supported on all platforms</h2>
       <section>
         <h2>Introduction</h2>
-        <p>APIs in this section are meant to be available in 2016 in a usable form in the four major web user agent code bases (though there are no requirements around explicit version number or release date for any client code bases). This is to enable the APIs to be delivered in consumer products in 2017.</p>
+        <p>This section defines the Web APIs to support media web apps that are supported across all four of the most widely used user agent code bases (though there are no requirements around explicit version number or release date for any client code bases). We encourage manufacturers to develop products that support these APIs.</p>
         <p>The approach taken in this draft is to only include specifications that are of particular significance to application programmers, but not include all the specifications cited by those included specifications. For example, IETF RFC 1345, Character Mnemonics and Character Sets [[RFC1345]] is required by the HTML5 spec included here, but is not included as a required specification here.</p>
         <section>
           <h3>APIs not widely implemented across all web platforms</h3>


### PR DESCRIPTION
This implements the consensus reached in https://github.com/w3c/webmediaapi/issues/70#issuecomment-316089816

Please take a minute to review the text and give it a thumbs up or a comment - this issue was discussed at length on telcos and via GitHub issues.