### PR TITLE
Fix #109 - remove CORS based on WebAppSec recommendation

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,6 @@
         <h3>Security specifications</h3>
         <p>Devices MUST be conforming implementations of the following specifications:</p>
         <ul>
-          <li> Cross-Origin Resource Sharing [[!CORS]]</li>
           <li> Content Security Policy Level 2 [[!CSP2]]</li>
           <li> Web Cryptography API [[!WebCryptoAPI]]</li>
         </ul>


### PR DESCRIPTION
Preemptive fix for #109.

Can be closed with no action if not required.