### PR TITLE
Fix #118 - remove WebDriver API and associated editors note.

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,6 @@
           <li> Cross-document messaging [[!WEB-MESSAGING]]</li>
           <li> Channel messaging [[!CHANNEL-MESSAGING]]</li>
           <li> Web Notifications [[!notifications-20151022]]</li>
-          <li> WebDriver [[!webdriver]]<p class="ednote">WebDriver API is at risk of removal from this specification pending a wider review of our test requirements. This issue is being tracked at <a href="https://github.com/w3c/webmediaapi/issues/118">https://github.com/w3c/webmediaapi/issues/118</a>.</p></li>
         </ul>
       </section>
     </section>


### PR DESCRIPTION
Implement consensus recorded in https://github.com/w3c/webmediaapi/issues/118#issuecomment-347242427.