### PR TITLE
Fix #124 - Change IndexedDB reference to Version 1 rather than LATEST

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,8 +169,8 @@
           <li> Web Workers [[!WORKERS]]
             <ul><li>Exceptions: <a href="https://www.w3.org/TR/workers/#shared-workers-and-the-sharedworker-interface">Shared Workers</a> are not yet widely supported.</li></ul>
           </li>
-          <li> Indexed Database API [[!INDEXEDDB]]
-            <ul><li>Exceptions: Array <a href="https://www.w3.org/TR/IndexedDB/#dfn-key-path">key path</a> and array <a href="https://www.w3.org/TR/IndexedDB/#dfn-key">keys</a> are not yet widely supported.</li></ul>
+          <li> Indexed Database API [[!IndexedDB-20150108]]
+            <ul><li>Exceptions: Array <a href="https://www.w3.org/TR/2015/REC-IndexedDB-20150108/#dfn-key-path">key path</a> and array <a href="https://www.w3.org/TR/2015/REC-IndexedDB-20150108/#dfn-key">keys</a> are not yet widely supported.</li></ul>
           </li>
           <li> Cross-document messaging [[!WEB-MESSAGING]]</li>
           <li> Channel messaging [[!CHANNEL-MESSAGING]]</li>


### PR DESCRIPTION
See #124 for discussion.

I believe this is purely editorial since the original intention was to reference version 1, just the referenced document changed underneath us.