### PR TITLE
Fix #122 - add a note encouraging WebGL implementation

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
       <section>
         <h3>Graphics specifications</h3>
         <ul>
-          <li> WebGL Specification, Version 1.0.3 [[WEBGL]]</li>
+          <li> WebGL Specification, Version 1.0.3 [[WEBGL]]<p class="note">Whilst WebGL is already supported in all four of the most widely used user agent code bases, hardware support may be required to implement the specification. Where performant hardware is present, the CG encourages implementation of the specification.</p></li>
         </ul>
        </section>
       <section>


### PR DESCRIPTION
Implements consensus recorded in https://github.com/w3c/webmediaapi/issues/122#issuecomment-351452362.

Please take a look at the wording.

This is a purely editorial change since it simply adds a non-normative note to a non-normative section.