### PR TITLE
Fix #127 - Correct Flexbox spec title

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
           <li> Compositing and Blending Level 1 [[!COMPOSITING]]</li>
           <li> CSS Transitions [[!CSS3-TRANSITIONS]]</li>
           <li> CSS Animations [[!CSS3-ANIMATIONS]]</li>
-          <li> CSS Flexible Box Module Level 1 [[!CSS-FLEXBOX-1]]</li>
+          <li> CSS Flexible Box Layout Module Level 1 [[!CSS-FLEXBOX-1]]</li>
           <li> CSS Transforms Module Level 1 [[!CSS-TRANSFORMS-1]]</li>
         </ul>
       </section>


### PR DESCRIPTION
This was previously "CSS Flexible Box Module Level 1", which was incorrectly inherited from CSS Snapshot 2017.