### PR TITLE
Fix #129 - correct media queries title

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
           <li> Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification [[!CSS2]]</li>
           <li> CSS Syntax Module Level 3 [[!CSS-SYNTAX-3]]</li>
           <li> CSS Style Attributes [[!CSS-STYLE-ATTR]]</li>
-          <li> Media Queries Level 3 [[!CSS3-MEDIAQUERIES]]</li>
+          <li> Media Queries [[!CSS3-MEDIAQUERIES]]</li>
           <li> CSS Conditional Rules Module Level 3 [[!CSS3-CONDITIONAL]]</li>
           <li> CSS Namespaces Module Level 3 [[!CSS-NAMESPACES-3]]</li>
           <li> Selectors Level 3 [[!SELECT]]</li>


### PR DESCRIPTION
Remove "Level 3" which was inherited from CSS Snapshot 2017