### PR TITLE
Fix #131 - WEBGL: Reference v1.0.3 rather than latest, and change title to match spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
       <section>
         <h3>Graphics specifications</h3>
         <ul>
-          <li> WebGL Specification, Version 1.0.3 [[WEBGL]]<p class="note">Whilst WebGL is already supported in all four of the most widely used user agent code bases, hardware support may be required to implement the specification. Where performant hardware is present, the CG encourages implementation of the specification.</p></li>
+          <li> WebGL Specification [[WEBGL-103]]<p class="note">Whilst WebGL is already supported in all four of the most widely used user agent code bases, hardware support may be required to implement the specification. Where performant hardware is present, the CG encourages implementation of the specification.</p></li>
         </ul>
        </section>
       <section>


### PR DESCRIPTION
Updated specref reference, and removed "Version 1.0.3" since that is not actually in the title.