### PR TITLE
Move David Evans to formerEditors

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,14 +10,14 @@
       var respecConfig = {
         specStatus: "CG-DRAFT",
         editors: [{
-          name: "David Evans",
-          company: "British Broadcasting Corporation",
-          companyURL: "https://www.bbc.co.uk/rd"
-        },
-        {
           name: "Mark Vickers",
           company: "Comcast",
           companyURL: "https://www.comcast.com"
+        }],
+        formerEditors: [{
+          name: "David Evans",
+          company: "British Broadcasting Corporation",
+          companyURL: "https://www.bbc.co.uk/rd"
         }],
         github: "https://github.com/w3c/webmediaapi",
         shortName: "dahut",


### PR DESCRIPTION
Sadly I can no longer continue as an editor of this specification. Removing myself from the list of editors and relegating to [`formerEditors`](https://github.com/w3c/respec/wiki/formerEditors).

A [`note`](https://github.com/w3c/respec/wiki/person) could be added to state at what point the status changed (eg 'until August 2018'), but I wasn't sure that was necessary.