### PR TITLE
Fix #138: Update to HTML 5.2 spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
         <h3>HTML core specifications</h3>
         <p>Devices MUST be conforming implementations of the following specifications:</p>
         <ul>
-          <li> HTML 5.1 [[!HTML51]], devices acting as Web browsers that support the HTML syntax and the XHTML syntax, scripting, and the suggested default rendering.</li>
+          <li> HTML 5.2 [[!HTML52]]</li>
           <li> ECMAScript Language Specification, Edition 5.1 [[!ECMASCRIPT-5.1]]</li>
         </ul>
       </section>

--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
         <p>Devices MUST be conforming implementations of the following specifications:</p>
         <ul>
           <li> HTML 5.2 [[!HTML52]]</li>
+            <ul><li>Note: Must support the Section 2.2.1 conformance class <code>Web browsers and other interactive user agents</code>.</li></ul>
           <li> ECMAScript Language Specification, Edition 5.1 [[!ECMASCRIPT-5.1]]</li>
         </ul>
       </section>

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         <p>Devices MUST be conforming implementations of the following specifications:</p>
         <ul>
           <li> HTML 5.2 [[!HTML52]]</li>
-            <ul><li>Note: Must support the Section 2.2.1 conformance class <code>Web browsers and other interactive user agents</code>.</li></ul>
+            <ul><li>Note: Must support the conformance class <code>Web browsers and other interactive user agents</code>.</li></ul>
           <li> ECMAScript Language Specification, Edition 5.1 [[!ECMASCRIPT-5.1]]</li>
         </ul>
       </section>


### PR DESCRIPTION
Update from HTML 5.1 to HTML 5.2, update specref accordingly & delete superfluous text after specref.

See #138 for discussion.