### PR TITLE
Fix #157: Fix Respect Error 2018-10-24

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
       <section class="informative">
         <h2>Introduction</h2>
         <p>This section lists the Web APIs to support media web apps that are supported across all four of the most widely used user agent code bases at the time of publication (though there are no requirements around explicit version number or release date for any client code bases). We encourage manufacturers to develop products that support the APIs in the most recent version of this specification.</p>
-        <p>The approach taken in this draft is only to include specifications that are of particular significance to authors, but not include all the specifications cited by those included specifications. For example, IETF RFC 1345, Character Mnemonics and Character Sets [[RFC1345]] is required by HTML 5.1 [[!HTML51]], and is therefore not included as a required specification here.</p>
+        <p>The approach taken in this draft is only to include specifications that are of particular significance to authors, but not include all the specifications cited by those included specifications. For example, HTTP is required by the HTML spec and is therefore not included as a required specification here.</p>
         <section>
           <h3>Features with limited implementation</h3>
           <p>Parts of some web specifications are not currently implemented across all user agent code bases and may never be. Consequently, these features will not be included in our tests. Any such features are noted as exceptions under that API.</p>


### PR DESCRIPTION
See #157 

- Change "HTML 5.1 [HTML51]" to simply "HTML" without a specific version reference, so that this non-normative text doesn't need to be updated each year.
- Change example from "IETF RFC 1345...[RFC1345]" to "HTTP" without a specific version reference, so that this non-normative text doesn't need to be updated each year.
- delete a comma before "and"