### PR TITLE
Update testSuiteURI to webapitests2019.ctawave.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         shortName: "WMAS2019",
         wg: "Web Media API Community Group",
         wgURI: "https://www.w3.org/community/webmediaapi/",
-        testSuiteURI: "https://webapitests2018.ctawave.org",
+        testSuiteURI: "https://webapitests2019.ctawave.org",
         copyrightStart: 2016,
         additionalCopyrightHolders: "Consumer Technology Association",
         logos: [{


### PR DESCRIPTION
https://webapitests2019.ctawave.org/ currently points to the 2018 tests but should be updated to be specific to 2019 in time for WMAS publishing in December 2019.

This closes #219.