### PR TITLE
Removing SVG reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,6 @@
         <ul>
           <li>Encrypted Media Extensions [[!ENCRYPTED-MEDIA]]</li>
           <li>Media Source Extensions [[!MEDIA-SOURCE]]</li>
-          <li>Scalable Vector Graphics (SVG) 1.1 (Second Edition) [[!SVG11]]</li>
           <li>Web Audio API [[!WEBAUDIO]]
             <ul>
               <li>Exceptions: Since not all environments currently support Media Streams [[MEDIACAPTURE-STREAMS]], <a href="https://www.w3.org/TR/webaudio/#mediastreamaudiosourcenode"><code>MediaStreamAudioSourceNode</code></a> and <a href="https://www.w3.org/TR/webaudio/#mediastreamaudiodestinationnode"><code>MediaStreamAudioDestinationNode</code></a> are not yet widely supported.</li>


### PR DESCRIPTION
Per #225, SVG 1.1 and HTML conflict with each other. By removing SVG, we essentially fall back to the SVG reference in HTML.

This closes #225.