### PR TITLE
Referencing commit snapshots for WHATWG standards

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,74 @@
           width: 100,
           height: 65,
           id: 'cta-logo',
-        }]
+        }],
+        refNote: "Since the WHATWG publishes living standards, each WHATWG standard listed below references the earliest commit in 2019 instead of the living standard. Devices must support the specified version of each WHATWG standard or later.",
+        localBiblio: {
+          "DOM": {
+            title: "DOM Standard",
+            authors: [
+              "Anne van Kesteren"
+            ],
+            href: "https://dom.spec.whatwg.org/commit-snapshots/37e62c0e4b132a95b861ba97f36b802643323a90/",
+            date: "2 January 2019",
+            status: "Commit Snapshot (use this version or later)",
+            publisher: "WHATWG"
+          },
+          "FETCH": {
+            title: "DOM Standard",
+            authors: [
+              "Anne van Kesteren"
+            ],
+            href: "https://fetch.spec.whatwg.org/commit-snapshots/939817ce80c08ac48232d8bce9ed1aca47567657/",
+            date: "15 January 2019",
+            status: "Commit Snapshot (use this version or later)",
+            publisher: "WHATWG"
+          },
+          "FULLSCREEN": {
+            title: "Fullscreen API Standard",
+            authors: [
+              "Philip Jägenstedt"
+            ],
+            href: "https://fullscreen.spec.whatwg.org/commit-snapshots/7ecd70946501abb8692bbf8ce72fa2b8d3ccf3ac/",
+            date: "23 January 2019",
+            status: "Commit Snapshot (use this version or later)",
+            publisher: "WHATWG"
+          },
+          "HTML": {
+            title: "HTML Standard",
+            authors: [
+              "Anne van Kesteren",
+              "Domenic Denicola",
+              "Ian Hickson",
+              "Philip Jägenstedt",
+              "Simon Pieters"
+            ],
+            href: "https://html.spec.whatwg.org/commit-snapshots/4fbaea9d440cf93953371627c065e358051fcf96/",
+            date: "3 January 2019",
+            status: "Commit Snapshot (use this version or later)",
+            publisher: "WHATWG"
+          },
+          "NOTIFICATIONS": {
+            title: "Notifications API Standard",
+            authors: [
+              "Anne van Kesteren"
+            ],
+            href: "https://notifications.spec.whatwg.org/commit-snapshots/4a053333020d52bd898f2a3cc2c6e1830bf00eff/",
+            date: "23 January 2019",
+            status: "Commit Snapshot (use this version or later)",
+            publisher: "WHATWG"
+          },
+          "XHR": {
+            title: "XMLHttpRequest Standard",
+            authors: [
+              "Anne van Kesteren"
+            ],
+            href: "https://xhr.spec.whatwg.org/commit-snapshots/43d3ba6028e8d67168b6f45e95c4987ad20ab8cf/",
+            date: "8 January 2019",
+            status: "Commit Snapshot (use this version or later)",
+            publisher: "WHATWG"
+          }
+        }
       };
     </script>
     <style>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
           height: 65,
           id: 'cta-logo',
         }],
-        refNote: "Since the WHATWG publishes living standards, each WHATWG standard listed below references the earliest commit in 2019 instead of the living standard. Devices must support the specified version of each WHATWG standard or later.",
+        refNote: "Since the WHATWG publishes living standards, each WHATWG standard listed below references the earliest commit in 2019 instead of the living standard. Devices must support the specified snapshot version of each WHATWG standard or later.",
         localBiblio: {
           "DOM": {
             title: "DOM Standard",

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
           height: 65,
           id: 'cta-logo',
         }],
-        refNote: "Since the WHATWG publishes living standards, each WHATWG standard listed below references the earliest commit in 2019 instead of the living standard. Devices must support the specified snapshot version of each WHATWG standard or later.",
+        refNote: "For WHATWG living standards, while it is recommended that devices support the living standard, they must support the snapshot version of each WHATWG standard at the time of the earliest commit in 2019 or a later version.",
         localBiblio: {
           "DOM": {
             title: "DOM Standard",


### PR DESCRIPTION
Also includes a note that devices must support the specified version of each WHATWG standard or later.

This fixes #224