### PR TITLE
Editorial: relocate refNote to reference section

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,6 @@
           height: 65,
           id: 'cta-logo',
         }],
-        refNote: "For WHATWG living standards, while it is recommended that devices support the living standard, they must support the snapshot version of each WHATWG standard at the time of the earliest commit in 2019 or a later version.",
         localBiblio: {
           "DOM": {
             title: "DOM Standard",
@@ -367,6 +366,9 @@
           <li>Web App Manifest [[APPMANIFEST]]</li>
         </ul>
       </section>
+    </section>
+    <section id="references">
+      <p>For WHATWG living standards, while it is recommended that devices support the living standard, they must support the snapshot version of each WHATWG standard at the time of the earliest commit in 2019 or a later version.</p>
     </section>
   </body>
 </html>


### PR DESCRIPTION
We are removing `refNote` from ReSpec. Please see https://github.com/w3c/respec/pull/2657