### PR TITLE
Updating WHATWG references to Review Drafts

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,9 +63,9 @@
             authors: [
               "Anne van Kesteren"
             ],
-            href: "https://dom.spec.whatwg.org/commit-snapshots/37e62c0e4b132a95b861ba97f36b802643323a90/",
-            date: "2 January 2019",
-            status: "Commit Snapshot (use this version or later)",
+            href: "https://dom.spec.whatwg.org/review-drafts/2019-06/",
+            date: "18 June 2019",
+            status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
           "FETCH": {
@@ -73,9 +73,9 @@
             authors: [
               "Anne van Kesteren"
             ],
-            href: "https://fetch.spec.whatwg.org/commit-snapshots/939817ce80c08ac48232d8bce9ed1aca47567657/",
-            date: "15 January 2019",
-            status: "Commit Snapshot (use this version or later)",
+            href: "https://fetch.spec.whatwg.org/review-drafts/2019-12/",
+            date: "13 December 2019",
+            status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
           "FULLSCREEN": {
@@ -83,9 +83,9 @@
             authors: [
               "Philip Jägenstedt"
             ],
-            href: "https://fullscreen.spec.whatwg.org/commit-snapshots/7ecd70946501abb8692bbf8ce72fa2b8d3ccf3ac/",
-            date: "23 January 2019",
-            status: "Commit Snapshot (use this version or later)",
+            href: "https://fullscreen.spec.whatwg.org/review-drafts/2020-01/",
+            date: "29 January 2020",
+            status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
           "HTML": {
@@ -97,9 +97,9 @@
               "Philip Jägenstedt",
               "Simon Pieters"
             ],
-            href: "https://html.spec.whatwg.org/commit-snapshots/4fbaea9d440cf93953371627c065e358051fcf96/",
-            date: "3 January 2019",
-            status: "Commit Snapshot (use this version or later)",
+            href: "https://html.spec.whatwg.org/review-drafts/2020-01/",
+            date: "29 January 2020",
+            status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
           "NOTIFICATIONS": {
@@ -107,9 +107,9 @@
             authors: [
               "Anne van Kesteren"
             ],
-            href: "https://notifications.spec.whatwg.org/commit-snapshots/4a053333020d52bd898f2a3cc2c6e1830bf00eff/",
-            date: "23 January 2019",
-            status: "Commit Snapshot (use this version or later)",
+            href: "https://notifications.spec.whatwg.org/review-drafts/2020-01/",
+            date: "29 January 2020",
+            status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
           "XHR": {
@@ -117,9 +117,9 @@
             authors: [
               "Anne van Kesteren"
             ],
-            href: "https://xhr.spec.whatwg.org/commit-snapshots/43d3ba6028e8d67168b6f45e95c4987ad20ab8cf/",
-            date: "8 January 2019",
-            status: "Commit Snapshot (use this version or later)",
+            href: "https://xhr.spec.whatwg.org/review-drafts/2020-02/",
+            date: "17 February 2020",
+            status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           }
         }
@@ -383,7 +383,7 @@
       </section>
     </section>
     <section id="references">
-      <p>For WHATWG living standards, while it is recommended that devices support the living standard, they must support the snapshot version of each WHATWG standard at the time of the earliest commit in 2019 or a later version.</p>
+      <p>For WHATWG living standards, while it is recommended that devices support the living standard, they must support the referenced review draft version of each WHATWG standard or a later commit snapshot version.</p>
     </section>
   </body>
 </html>


### PR DESCRIPTION
Note as part of this, we're switching from commit snapshots to review drafts

This addresses #249 