### PR TITLE
Update to ECMAscript 2020

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,18 @@
         <p>Devices MUST be conforming implementations of the following specifications:</p>
         <ul>
           <li>DOM [[!DOM]]</li>
-          <li>ECMAScript Language Specification, Edition 7 [[!ECMASCRIPT-7.0]]</li>
+          <li>ECMAScript 2020 Language Specification [[!ECMASCRIPT-2020]]
+            <ul>
+              <li>Exceptions:
+                <ul>
+                  <li><a href="https://www.ecma-international.org/ecma-262/#sec-sharedarraybuffer-objects"><code>SharedArrayBuffer</code></a> is not yet widely supported in an effort to mitigate the <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">Spectre attack</a>.</li>
+                  <li><a href="https://www.ecma-international.org/ecma-262/#sec-atomics-object"><code>Atomics</code></a> are not yet widely supported.</li>
+                  <li><a href="https://www.ecma-international.org/ecma-262/#prod-Assertion">look-behind assertions</a> are not yet widely supported.</li>
+                  <li>The <a href="https://www.ecma-international.org/ecma-262/#sec-function.prototype.tostring"><code>Function.prototype.toString</code> revisions from ECMAScript 2019</a> are not yet widely supported.</li>
+                  <li><a href="https://www.ecma-international.org/ecma-262/#sec-terms-and-definitions-bigint-value"><code>BigInt</code></a> is not yet widely supported.</li>
+               </ul>
+            </ul>
+          </li>
           <li>HTML [[!HTML]]
             <ul>
               <li>Devices MUST support the conformance class <b><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#interactive">Web browsers and other interactive user agents</a></b>.</li>


### PR DESCRIPTION
This fixes #254 

Note that from [ES10](https://www.ecma-international.org/ecma-262/10.0/) to [ES11](https://www.ecma-international.org/ecma-262/11.0/), the editors of ECMAScript appear to have given more focus to the year aspect of the revision numbering than the sequential order, so I've chosen to use "ECMAScript 2020" as the way we reference it instead of "ECMAScript 11" as a result of that.

Related specref change that ~will need to be merged before this is merged~ has been merged: https://github.com/tobie/specref/pull/618