### PR TITLE
Switch to "respec-w3c" profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Web Media API Snapshot 2020</title>
     <script
-     src="https://www.w3.org/Tools/respec/respec-w3c-common"
+     src="https://www.w3.org/Tools/respec/respec-w3c"
      class="remove">
     </script>
     <script class="remove">
@@ -37,8 +37,7 @@
         }],
         github: "https://github.com/w3c/webmediaapi",
         shortName: "WMAS2020",
-        wg: "Web Media API Community Group",
-        wgURI: "https://www.w3.org/community/webmediaapi/",
+        group: "webmediaapi",
         testSuiteURI: "https://webapitests2020.ctawave.org/wave/",
         copyrightStart: 2016,
         additionalCopyrightHolders: "Consumer Technology Association",


### PR DESCRIPTION
The previous "respec-w3c-common" has been deprecated. The CG is not affected by Process 2020, but it is still good practice to use the latest version of Respec and the old profile will no longer be updated.

Switching to the new profile allows to associate the spec with the group more easily through the new `group` property, as done in this update. The switch should not have any other impact on the contents of the spec.

Addresses #268.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webmediaapi/pull/269.html" title="Last updated on Oct 2, 2020, 6:16 PM UTC (2b950c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/269/59b426f...tidoust:2b950c6.html" title="Last updated on Oct 2, 2020, 6:16 PM UTC (2b950c6)">Diff</a>