### PR TITLE
Update to ECMAscript 2021 / 12.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,15 +193,15 @@
         <p>Devices MUST be conforming implementations of the following specifications:</p>
         <ul>
           <li>DOM [[!DOM]]</li>
-          <li>ECMAScript 2020 Language Specification [[!ECMASCRIPT-2020]]
+          <li>ECMAScript 2021 Language Specification [[!ECMASCRIPT-2021]]
             <ul>
               <li>Exceptions:
                 <ul>
-                  <li><a href="https://www.ecma-international.org/ecma-262/#sec-sharedarraybuffer-objects"><code>SharedArrayBuffer</code></a> is not yet widely supported in an effort to mitigate the <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">Spectre attack</a>.</li>
-                  <li><a href="https://www.ecma-international.org/ecma-262/#sec-atomics-object"><code>Atomics</code></a> are not yet widely supported.</li>
-                  <li><a href="https://www.ecma-international.org/ecma-262/#prod-Assertion">look-behind assertions</a> are not yet widely supported.</li>
-                  <li>The <a href="https://www.ecma-international.org/ecma-262/#sec-function.prototype.tostring"><code>Function.prototype.toString</code> revisions from ECMAScript 2019</a> are not yet widely supported.</li>
-                  <li><a href="https://www.ecma-international.org/ecma-262/#sec-terms-and-definitions-bigint-value"><code>BigInt</code></a> is not yet widely supported.</li>
+                  <li><a href="https://262.ecma-international.org/12.0/#sec-sharedarraybuffer-objects"><code>SharedArrayBuffer</code></a> is not yet widely supported in an effort to mitigate the <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">Spectre attack</a>.</li>
+                  <li><a href="https://262.ecma-international.org/12.0/#sec-atomics-object"><code>Atomics</code></a> are not yet widely supported.</li>
+                  <li><a href="https://262.ecma-international.org/12.0/#prod-Assertion">look-behind assertions</a> are not yet widely supported.</li>
+                  <li>The <a href="https://262.ecma-international.org/12.0/#sec-function.prototype.tostring"><code>Function.prototype.toString</code> revisions from ECMAScript 2019</a> are not yet widely supported.</li>
+                  <li>The <a href="https://262.ecma-international.org/12.0/#sec-typedarray-objects"><code>BigInt64Array</code></a>, <a href="https://262.ecma-international.org/12.0/#sec-typedarray-objects"><code>BigUint64Array</code></a>, <a href="https://262.ecma-international.org/12.0/#sec-dataview.prototype.getbigint64"><code>DataView.prototype.getBigInt64</code></a>, and <a href="https://262.ecma-international.org/12.0/#sec-dataview.prototype.getbiguint64"><code>DataView.prototype.getBigUint64</code></a> features of <a href="https://262.ecma-international.org/12.0/#sec-terms-and-definitions-bigint-value"><code>BigInt</code></a> are not yet widely supported.</li>
                </ul>
             </ul>
           </li>


### PR DESCRIPTION
This addresses #276 

Paths to all ECMAscript links have been updated to specifically reference the 2021 version as the old links are no longer valid

Related specref change that ~will need to be merged before this is~ has been merged: https://github.com/tobie/specref/pull/680


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/284.html" title="Last updated on Aug 18, 2021, 2:02 PM UTC (94aca5d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/284/e78a680...94aca5d.html" title="Last updated on Aug 18, 2021, 2:02 PM UTC (94aca5d)">Diff</a>