### PR TITLE
Update test suite URL to 2021

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         github: "https://github.com/w3c/webmediaapi",
         shortName: "WMAS2021",
         group: "webmediaapi",
-        testSuiteURI: "https://webapitests2020.ctawave.org/wave/",
+        testSuiteURI: "https://webapitests2021.ctawave.org/wave/",
         copyrightStart: 2016,
         additionalCopyrightHolders: "Consumer Technology Association",
         logos: [{


### PR DESCRIPTION
https://webapitests2021.ctawave.org/wave/ URL is now active (with older test suite)

This addresses #282


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/289.html" title="Last updated on Sep 15, 2021, 2:24 PM UTC (58f4e77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/289/055b0ee...58f4e77.html" title="Last updated on Sep 15, 2021, 2:24 PM UTC (58f4e77)">Diff</a>