### PR TITLE
Update to ECMAscript 2022 / 13.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,15 +194,14 @@
         <p>Devices MUST be conforming implementations of the following specifications:</p>
         <ul>
           <li>DOM [[!DOM]]</li>
-          <li>ECMAScript 2021 Language Specification [[!ECMASCRIPT-2021]]
+          <li>ECMAScript 2022 Language Specification [[!ECMASCRIPT-2022]]
             <ul>
               <li>Exceptions:
                 <ul>
-                  <li><a href="https://262.ecma-international.org/12.0/#sec-sharedarraybuffer-objects"><code>SharedArrayBuffer</code></a> is not yet widely supported in an effort to mitigate the <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">Spectre attack</a>.</li>
-                  <li><a href="https://262.ecma-international.org/12.0/#sec-atomics-object"><code>Atomics</code></a> are not yet widely supported.</li>
-                  <li><a href="https://262.ecma-international.org/12.0/#prod-Assertion">look-behind assertions</a> are not yet widely supported.</li>
-                  <li>The <a href="https://262.ecma-international.org/12.0/#sec-function.prototype.tostring"><code>Function.prototype.toString</code> revisions from ECMAScript 2019</a> are not yet widely supported.</li>
-                  <li>The <a href="https://262.ecma-international.org/12.0/#sec-typedarray-objects"><code>BigInt64Array</code></a>, <a href="https://262.ecma-international.org/12.0/#sec-typedarray-objects"><code>BigUint64Array</code></a>, <a href="https://262.ecma-international.org/12.0/#sec-dataview.prototype.getbigint64"><code>DataView.prototype.getBigInt64</code></a>, and <a href="https://262.ecma-international.org/12.0/#sec-dataview.prototype.getbiguint64"><code>DataView.prototype.getBigUint64</code></a> features of <a href="https://262.ecma-international.org/12.0/#sec-terms-and-definitions-bigint-value"><code>BigInt</code></a> are not yet widely supported.</li>
+                  <li><a href="https://262.ecma-international.org/13.0/#prod-Assertion">look-behind assertions</a> are not yet widely supported.</li>
+                  <li>The <a href="https://262.ecma-international.org/13.0/#sec-function.prototype.tostring"><code>Function.prototype.toString</code> revisions from ECMAScript 2019</a> are not yet widely supported.</li>
+                  <li><a href="https://262.ecma-international.org/13.0/#sec-classstaticblockdefinition-record-specification-type">Class static initialization blocks</a> are not yet widely supported.</li>
+                  <li><a href="https://262.ecma-international.org/13.0/#sec-get-regexp.prototype.hasIndices">RegExp Match Indices (hasIndices <code>/d</code> flag)</a> is not yet widely supported.</li>
                </ul>
             </ul>
           </li>


### PR DESCRIPTION
Adjustments as a result of the update:
- 3 exceptions removed:
  - `SharedArrayBuffer`
  - `Atomics`
  - `BigInt`
- 2 new exceptions:
  - Class static initialization blocks
  - RegExp Match Indices (hasIndices `/d` flag)

Related specref change that ~will need to be merged before this is~ was merged: https://github.com/tobie/specref/pull/718

This addresses #298


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/305.html" title="Last updated on Aug 20, 2022, 3:31 PM UTC (36f7a45)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/305/1ba764f...36f7a45.html" title="Last updated on Aug 20, 2022, 3:31 PM UTC (36f7a45)">Diff</a>