### PR TITLE
Update test suite URL to 2022

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         github: "https://github.com/w3c/webmediaapi",
         shortName: "WMAS2022",
         group: "webmediaapi",
-        testSuiteURI: "https://webapitests2021.ctawave.org/wave/",
+        testSuiteURI: "https://webapitests2022.ctawave.org/wave/",
         copyrightStart: 2016,
         additionalCopyrightHolders: "Consumer Technology Association",
         logos: [{


### PR DESCRIPTION
This addresses #308


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/309.html" title="Last updated on Oct 11, 2022, 4:27 PM UTC (6b65782)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/309/1ba764f...6b65782.html" title="Last updated on Oct 11, 2022, 4:27 PM UTC (6b65782)">Diff</a>