### PR TITLE
CSS Updates for 2023

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
       </section>
       <section>
         <h3>CSS specifications</h3>
-        <p>Devices MUST be conforming implementations of the following specifications (CSS Snapshot 2018 [[?CSS-2018]]):</p>
+        <p>Devices MUST be conforming implementations of the following specifications, which are derived from the official Cascading Style Sheets definition from CSS Snapshot 2018 [[?CSS-2018]] as well as more recent revisions to CSS specifications as appropriate:</p>
         <p class="note" role="note">As part of the updates included in CSS Snapshot 2018, the <a href="https://www.w3.org/TR/css-2018/#profiles">CSS Profiles</a> effort was discontinued.</p>
         <ul>
           <li>Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification [[!CSS2]]</li>
@@ -235,7 +235,7 @@
           <li>CSS Backgrounds and Borders Module Level 3 [[!CSS3-BACKGROUND]]</li>
           <li>CSS Basic User Interface Module Level 3 (CSS3 UI) [[!CSS-UI-3]]</li>
           <li>CSS Cascading and Inheritance Level 4 [[!CSS-CASCADE-4]]</li>
-          <li>CSS Color Module Level 3 [[!CSS3-COLOR]]</li>
+          <li>CSS Color Module Level 4 [[!CSS-COLOR-4]]</li>
           <li>CSS Conditional Rules Module Level 3 [[!CSS3-CONDITIONAL]]</li>
           <li>CSS Containment Module Level 1 [[!CSS-CONTAIN-1]]</li>
           <li>CSS Custom Properties For Cascading Variables Module Level 1 [[!CSS-VARIABLES-1]]</li>


### PR DESCRIPTION
- Updating CSS Color Module from Level 3 to Level 4
- Updating wording of the initial CSS specifications text

This addresses #312


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/323.html" title="Last updated on Aug 10, 2023, 6:47 PM UTC (eda1be0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/323/28fab69...eda1be0.html" title="Last updated on Aug 10, 2023, 6:47 PM UTC (eda1be0)">Diff</a>