### PR TITLE
WHATWG updates for 2023

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,8 +63,8 @@
             authors: [
               "Anne van Kesteren"
             ],
-            href: "https://dom.spec.whatwg.org/review-drafts/2021-06/",
-            date: "21 June 2021",
+            href: "https://dom.spec.whatwg.org/review-drafts/2022-06/",
+            date: "20 June 2022",
             status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
@@ -73,8 +73,8 @@
             authors: [
               "Anne van Kesteren"
             ],
-            href: "https://fetch.spec.whatwg.org/review-drafts/2021-12/",
-            date: "19 December 2021",
+            href: "https://fetch.spec.whatwg.org/review-drafts/2022-12/",
+            date: "19 December 2022",
             status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
@@ -83,8 +83,8 @@
             authors: [
               "Philip Jägenstedt"
             ],
-            href: "https://fullscreen.spec.whatwg.org/review-drafts/2022-01/",
-            date: "17 January 2022",
+            href: "https://fullscreen.spec.whatwg.org/review-drafts/2023-01/",
+            date: "16 January 2023",
             status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
@@ -97,8 +97,8 @@
               "Philip Jägenstedt",
               "Simon Pieters"
             ],
-            href: "https://html.spec.whatwg.org/review-drafts/2022-01/",
-            date: "17 January 2022",
+            href: "https://html.spec.whatwg.org/review-drafts/2023-01/",
+            date: "16 January 2023",
             status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
@@ -107,8 +107,18 @@
             authors: [
               "Anne van Kesteren"
             ],
-            href: "https://notifications.spec.whatwg.org/review-drafts/2022-01/",
-            date: "17 January 2022",
+            href: "https://notifications.spec.whatwg.org/review-drafts/2023-01/",
+            date: "16 January 2023",
+            status: "Review Draft (use this version or later)",
+            publisher: "WHATWG"
+          },
+          "WEBSOCKETS": {
+            title: "WebSockets Standard",
+            authors: [
+              "Adam Rice"
+            ],
+            href: "https://websockets.spec.whatwg.org/review-drafts/2022-09/",
+            date: "19 September 2022",
             status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
@@ -117,8 +127,8 @@
             authors: [
               "Anne van Kesteren"
             ],
-            href: "https://xhr.spec.whatwg.org/review-drafts/2022-02/",
-            date: "21 February 2022",
+            href: "https://xhr.spec.whatwg.org/review-drafts/2023-02/",
+            date: "20 February 2023",
             status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           }
@@ -215,9 +225,8 @@
               </li>
               <li>Exceptions:
                 <ul>
-                  <li><a href="https://html.spec.whatwg.org/multipage/workers.html#shared-workers-and-the-sharedworker-interface"><code>SharedWorker</code></a> is not yet widely supported.</li>
                   <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#css-module-script">CSS module scripts</a> are not yet widely supported.</li>
-                  <li><a href="https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports"><code>HTMLScriptElement.supports(type)</code></a> is not yet widely supported.</li>
+                  <li>The <a href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden-until-found-keyword"><code>hidden=until-found</code></a> HTML attribute and the <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers-on-elements,-document-objects,-and-window-objects:event-beforematch"><code>beforematch</code></a> event are not yet widely supported.</li>
                 </ul>
               </li>
             </ul>
@@ -310,8 +319,8 @@
         <p>Devices MUST be conforming implementations of the following specifications:</p>
         <ul>
           <li>Fetch [[!FETCH]]</li>
+          <li>WebSockets [[!WEBSOCKETS]]</li>
           <li>XMLHttpRequest [[!XHR]]</li>
-          <li>Note: Web sockets is also required as part of the HTML specification [[!HTML]].</li>
         </ul>
       </section>
       <section>


### PR DESCRIPTION
- Advanced all review draft references by 1 year
- Removed 2 exceptions for HTML (`SharedWorke` and `HTMLScriptElement.supports(type)`)
- Added a new exception for HTML (`hidden=until-found` / `beforematch`)
- Added the WebSockets WHATWG specification

This addresses #314


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/324.html" title="Last updated on Aug 10, 2023, 7:36 PM UTC (9a7f99b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/324/28fab69...9a7f99b.html" title="Last updated on Aug 10, 2023, 7:36 PM UTC (9a7f99b)">Diff</a>