### PR TITLE
2023 spec updates for Section 5: Web Media APIs proposed to be supported on all platforms

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,6 +276,11 @@
         <ul>
           <li>Encrypted Media Extensions [[!ENCRYPTED-MEDIA]]</li>
           <li>Media Capabilities [[!MEDIA-CAPABILITIES]]</li>
+          <li>Media Fragments URI 1.0 (basic) [[!MEDIA-FRAGS]]
+            <ul>
+              <li>Note: Support is limited to video track ranges.
+            </ul>
+          </li>
           <li>Media Source Extensions [[!MEDIA-SOURCE]]</li>
           <li>Web Audio API [[!WEBAUDIO]]</li>
           <li>WebRTC 1.0: Real-Time Communication Between Browsers [[!WEBRTC]]
@@ -390,7 +395,6 @@
       <section>
         <h3>Media specifications</h3>
         <ul>
-          <li>Media Fragments URI 1.0 (basic) [[MEDIA-FRAGS]]</li>
           <li>Media Session Standard [[MEDIASESSION]]</li>
           <li>Sourcing In-band Media Resource Tracks from Media Containers into HTML [[INBANDTRACKS]]</li>
           <li>WebCodecs [[WEBCODECS]]</li>
@@ -408,6 +412,7 @@
         <h3>Other web specifications</h3>
         <ul>
           <li>Web App Manifest [[APPMANIFEST]]</li>
+          <li>WebTransport [[WEBTRANSPORT]]</li>
         </ul>
       </section>
     </section>


### PR DESCRIPTION
- `Media Fragments URI 1.0 (basic)` moved to section **3.5 Media specifications** with note that "Support is limited to video track ranges."
- Adding `WebTransport` to **Section 5: Web Media APIs proposed to be supported on all platforms**

This addresses #315


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/325.html" title="Last updated on Aug 11, 2023, 6:36 PM UTC (3b6ad56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/325/28fab69...3b6ad56.html" title="Last updated on Aug 11, 2023, 6:36 PM UTC (3b6ad56)">Diff</a>