### PR TITLE
Adding 2024 binding

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,17 @@
             date: "20 February 2023",
             status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
+          },
+          "CTA-5000-G": {
+            title: "Web Media API Snapshot 2024 CTA-5000-G",
+            authors: [
+              "Jon Piesing",
+              "John Riviello"
+            ],
+            href: "https://cdn.cta.tech/cta/media/media/resources/standards/pdfs/cta-5000-g-final.pdf",
+            date: "October 2024",
+            publisher: "Consumer Technology Association",
+            status: "CTA Specification"
           }
         }
       };
@@ -481,6 +492,10 @@
           <tr>
             <td>urn:cta:wave:appinformation:standardversion:cta5000f:2023</td>
             <td>Web Media API Snapshot 2023 CTA-5000-F [[CTA-5000-F]]</td>
+          </tr>
+          <tr>
+            <td>urn:cta:wave:appinformation:standardversion:cta5000g:2024</td>
+            <td>Web Media API Snapshot 2024 CTA-5000-G [[CTA-5000-G]]</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
This addresses #347 

This will be the last PR we'll merge prior to submitting for TWG review, as the link for CTA-5000-G won't work until the WMAS2024 is approved & published


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/358.html" title="Last updated on Aug 14, 2024, 1:49 PM UTC (0ec96e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/358/ba12f53...0ec96e6.html" title="Last updated on Aug 14, 2024, 1:49 PM UTC (0ec96e6)">Diff</a>