### PR TITLE
Removing the W3C logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,13 +44,6 @@
         copyrightStart: 2016,
         additionalCopyrightHolders: "Consumer Technology Association",
         logos: [{
-          src: 'https://www.w3.org/StyleSheets/TR/2016/logos/W3C',
-          href: "https://www.w3.org",
-          alt: "World Wide Web Consortium (W3C)",
-          width: 72,
-          height: 48,
-          id: 'w3c-logo',
-        }, {
           src: 'https://cdn.cta.tech/cta/media/media/home/cta-logo.png',
           href: "https://cta.tech/Research-Standards.aspx",
           alt: "Consumer Technology Association (CTA)",


### PR DESCRIPTION
The W3C no longer includes their logo on top of CG reports


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/362.html" title="Last updated on Oct 16, 2024, 5:18 PM UTC (2ceb07d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/362/b1f6697...2ceb07d.html" title="Last updated on Oct 16, 2024, 5:18 PM UTC (2ceb07d)">Diff</a>