### PR TITLE
Adding HTTP Strict Transport Security (HSTS)

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,6 +369,7 @@
         <p>Devices MUST be conforming implementations of the following specifications:</p>
         <ul>
           <li>Content Security Policy Level 2 [[!CSP2]]</li>
+          <li>HTTP Strict Transport Security (HSTS) [[!RFC6797]]</li>
           <li>Referrer Policy [[!REFERRER-POLICY]]</li>
           <li>Subresource Integrity [[!SRI]]</li>
           <li>Transport Layer Security (TLS) Protocol Version 1.2 [[!RFC5246]]</li>


### PR DESCRIPTION
addresses #368


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/374.html" title="Last updated on Jan 15, 2025, 9:53 PM UTC (3784340)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/374/adc9a2d...3784340.html" title="Last updated on Jan 15, 2025, 9:53 PM UTC (3784340)">Diff</a>