### PR TITLE
Updating WebRTC title to match renamed spec title

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@
           </li>
           <li>Media Source Extensions [[!MEDIA-SOURCE-1]]</li>
           <li>Web Audio API [[!WEBAUDIO]]</li>
-          <li>WebRTC 1.0: Real-Time Communication Between Browsers [[!WEBRTC]]
+          <li>WebRTC: Real-Time Communication in Browsers [[!WEBRTC]]
             <ul>
               <li>Note: Since consumer products may not have camera and/or microphone inputs to send video and audio, WebRTC's functionality can be limited to not allow an <a href="https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiverdirection"><code>RTCRtpTransceiverDirection</code></a> of "<code>sendrecv</code>" or "<code>sendonly</code>" on those devices. This also implies the <a href="https://www.w3.org/TR/webrtc/#rtcrtpsender-interface"><code>RTCRtpSender</code> interface</a> is not required to be implemented, and the Media Capture and Streams [[GETUSERMEDIA]] requirements are limited to <a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediastream"><code>MediaStream</code></a>, <a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack"><code>MediaStreamTrack</code></a>, and <a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamconstraints"><code>MediaStreamConstraints</code></a> as defined in Media Capture and Streams and extended by WebRTC. This enables WebRTC to be leveraged for use cases such as security camera feeds, ultra low latency live streaming, and cloud gaming.
             </ul>


### PR DESCRIPTION
This fixes #370


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/376.html" title="Last updated on Jan 22, 2025, 4:31 PM UTC (31875f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/376/b6a127a...31875f9.html" title="Last updated on Jan 22, 2025, 4:31 PM UTC (31875f9)">Diff</a>