### PR TITLE
Removed explicit reference to HTML Canvas 2D Context

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,10 +333,10 @@
         <ul>
           <li>Fullscreen API Standard [[!FULLSCREEN]]</li>
           <li>Graphics Interchange Format [[!GIF]]</li>
-          <li>HTML Canvas 2D Context [[!2DCONTEXT]]</li>
           <li>JPEG File Interchange Format [[!JPEG]]</li>
           <li>Portable Network Graphics (PNG) Specification (Second Edition) [[!PNG2e-20031110]]</li>
           <li>WebGL Specification [[!WEBGL-103]]</li>
+          <li>Note: HTML Canvas 2D Context is also required as part of the HTML specification [[!HTML]].</li>
         </ul>
       </section>
       <section>


### PR DESCRIPTION
and instead added a note that it is required as part of HTML

This fixes #371


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/377.html" title="Last updated on Jan 16, 2025, 4:32 PM UTC (92a3f15)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/377/adc9a2d...92a3f15.html" title="Last updated on Jan 16, 2025, 4:32 PM UTC (92a3f15)">Diff</a>