### PR TITLE
Updates for when WMAS2024 Errata is published

### DIFF
--- a/errata/wmas2024.html
+++ b/errata/wmas2024.html
@@ -112,8 +112,10 @@
       <dl>
         <dt>Latest Errata Update:</dt>
         <dd><span id="date">Fri 11 April 2025</span></dd>
-        <dt>Latest Published Version of WMAS2024:</dt>
+        <dt>Original Published Version of WMAS2024:</dt>
         <dd><a href="https://www.w3.org/community/reports/webmediaapi/CG-FINAL-webmediaapi-20241016/">https://www.w3.org/community/reports/webmediaapi/CG-FINAL-webmediaapi-20241016/</a></dd>
+        <dt>Latest Published Version of WMAS2024 with these Errata changes:</dt>
+        <dd><a href="https://www.w3.org/community/reports/webmediaapi/CG-FINAL-webmediaapi-20250411/">https://www.w3.org/community/reports/webmediaapi/CG-FINAL-webmediaapi-20250411/</a></dd>
         <dt>Latest Editor&rsquo;s Draft of WMAS:</dt>
         <dd><a href="https://w3c.github.io/webmediaapi/">https://w3c.github.io/webmediaapi/</a></dd>
       </dl>


### PR DESCRIPTION
To be merged once https://github.com/w3c/cg-reports/pull/59 is merged and published