### PR TITLE
README and Spec updates related to 2024 Errata

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains the Web Media API Snapshot specification that is being 
 - [Web Media API Snapshot 2023](https://www.w3.org/2023/11/webmediaapi.html) was published 06 November 2023.
 - [Web Media API Snapshot 2023 (WMAS 2023) Test Suite](https://webapitests2023.ctawave.org) is available for testing devices.
 - [Web Media API Snapshot 2024](https://www.w3.org/community/reports/webmediaapi/CG-FINAL-webmediaapi-20241016/) was published 16 October 2024.
+- [Web Media API Snapshot 2024 (April 2025 update with Errata)](https://www.w3.org/community/reports/webmediaapi/CG-FINAL-webmediaapi-20250411/) was published 11 April 2025.
 - Web Media API Snapshot 2025 is planned to be published Q4 2025.
 - [Web Media API Snapshot](https://w3c.github.io/webmediaapi/) is the latest version on the repository.
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <script class="remove">
       var respecConfig = {
         specStatus: "CG-DRAFT",
-        latestVersion: "https://www.w3.org/community/reports/webmediaapi/CG-FINAL-webmediaapi-20241016/",
+        latestVersion: "https://www.w3.org/community/reports/webmediaapi/CG-FINAL-webmediaapi-20250411/",
         editors: [{
           name: "Jon Piesing",
           company: "TP Vision Belgium N.V.",
@@ -132,8 +132,19 @@
               "Jon Piesing",
               "John Riviello"
             ],
-            href: "https://cdn.cta.tech/cta/media/media/resources/standards/cta-5000-g-final.pdf",
+            href: "https://www.cta.tech/resources-folder/standards/cta-5000-g/",
             date: "October 2024",
+            publisher: "Consumer Technology Association",
+            status: "CTA Specification"
+          },
+          "CTA-5000-G-ERRATA": {
+            title: "Web Media API Snapshot 2024 CTA-5000-G and Errata",
+            authors: [
+              "Jon Piesing",
+              "John Riviello"
+            ],
+            href: "https://www.cta.tech/resources-folder/standards/cta-5000-g-errata/",
+            date: "April 2025",
             publisher: "Consumer Technology Association",
             status: "CTA Specification"
           }
@@ -508,6 +519,10 @@
           <tr>
             <td>urn:cta:wave:appinformation:standardversion:cta5000g:2024</td>
             <td>Web Media API Snapshot 2024 CTA-5000-G [[CTA-5000-G]]</td>
+          </tr>
+          <tr>
+            <td>urn:cta:wave:appinformation:standardversion:cta5000g-errata:2024</td>
+            <td>Web Media API Snapshot 2024 CTA-5000-G &amp; Errata [[CTA-5000-G-ERRATA]]</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
- Add Web Media API Snapshot 2024 (April 2025 update with Errata) to README.md
- Update the lastestVersion
- Update Annex A with links to 2024 Errata and updated WMAS2024 link (pointing to CTA store)

This addresses #384


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/385.html" title="Last updated on May 12, 2025, 7:39 PM UTC (1740afd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/385/276ae01...1740afd.html" title="Last updated on May 12, 2025, 7:39 PM UTC (1740afd)">Diff</a>