### PR TITLE
CSS Updates for 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
       </section>
       <section>
         <h3>CSS specifications</h3>
-        <p>Devices MUST be conforming implementations of the following specifications, which are derived from the official Cascading Style Sheets definition from CSS Snapshot 2023 [[?CSS-2023]] as well as more recent revisions to CSS specifications as appropriate:</p>
+        <p>Devices MUST be conforming implementations of the following specifications, which are derived from the official Cascading Style Sheets definition from CSS Snapshot 2024 [[?CSS-2024]] as well as more recent revisions to CSS specifications as appropriate:</p>
         <ul>
           <li>Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification [[!CSS2]]</li>
           <li>Compositing and Blending Level 1 [[!COMPOSITING]]</li>
@@ -287,7 +287,7 @@
           <li>CSS Flexible Box Layout Module Level 1 [[!CSS-FLEXBOX-1]]</li>
           <li>CSS Font Loading Module Level 3 [[!CSS-FONT-LOADING-3]]</li>
           <li>CSS Fonts Module Level 3 [[!CSS-FONTS-3]]</li>
-          <li>CSS Grid Layout Module Level 1 [[!CSS-GRID-1]]</li>
+          <li>CSS Grid Layout Module Level 2 [[!CSS-GRID-2]]</li>
           <li>CSS Images Module Level 3 [[!CSS-IMAGES-3]]</li>
           <li>CSS Logical Properties and Values Level 1 [[!CSS-LOGICAL-1]]</li>
           <li>CSS Multi-column Layout Module Level 1 [[!CSS-MULTICOL-1]]</li>


### PR DESCRIPTION
- Updated CSS Snapshot to 2024
- Replaced Grid Level 1 with Grid Level 2

This addresses #387


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/394.html" title="Last updated on Aug 4, 2025, 4:56 PM UTC (28e3dd8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/394/1c1cb16...28e3dd8.html" title="Last updated on Aug 4, 2025, 4:56 PM UTC (28e3dd8)">Diff</a>