### PR TITLE
Removing localBiblio entries for 2024 WMAS Bindings that are now in Specref

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,28 +125,6 @@
             date: "19 February 2024",
             status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
-          },
-          "CTA-5000-G": {
-            title: "Web Media API Snapshot 2024 CTA-5000-G",
-            authors: [
-              "Jon Piesing",
-              "John Riviello"
-            ],
-            href: "https://www.cta.tech/resources-folder/standards/cta-5000-g/",
-            date: "October 2024",
-            publisher: "Consumer Technology Association",
-            status: "CTA Specification"
-          },
-          "CTA-5000-G-ERRATA": {
-            title: "Web Media API Snapshot 2024 CTA-5000-G and Errata",
-            authors: [
-              "Jon Piesing",
-              "John Riviello"
-            ],
-            href: "https://www.cta.tech/resources-folder/standards/cta-5000-g-errata/",
-            date: "April 2025",
-            publisher: "Consumer Technology Association",
-            status: "CTA Specification"
           }
         }
       };


### PR DESCRIPTION
- Web Media API Snapshot 2024 CTA-5000-G
- Web Media API Snapshot 2024 CTA-5000-G and Errata

Addresses the first part of #391


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/398.html" title="Last updated on Sep 3, 2025, 3:25 PM UTC (3d91192)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/398/4832f30...3d91192.html" title="Last updated on Sep 3, 2025, 3:25 PM UTC (3d91192)">Diff</a>