### PR TITLE
Adding 2025 binding

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,17 @@
             date: "April 2025",
             publisher: "Consumer Technology Association",
             status: "CTA Specification"
+          },
+          "CTA-5000-H": {
+            title: "Web Media API Snapshot 2025 CTA-5000-H",
+            authors: [
+              "Jon Piesing",
+              "John Riviello"
+            ],
+            href: "https://www.cta.tech/resources-folder/standards/cta-5000-h/",
+            date: "October 2025",
+            publisher: "Consumer Technology Association",
+            status: "CTA Specification"
           }
         }
       };
@@ -523,6 +534,10 @@
           <tr>
             <td>urn:cta:wave:appinformation:standardversion:cta5000g-errata:2024</td>
             <td>Web Media API Snapshot 2024 CTA-5000-G &amp; Errata [[CTA-5000-G-ERRATA]]</td>
+          </tr>
+          <tr>
+            <td>urn:cta:wave:appinformation:standardversion:cta5000h:2025</td>
+            <td>Web Media API Snapshot 2025 CTA-5000-H [[CTA-5000-H]]</td>
           </tr>
         </tbody>
       </table>

--- a/index.html
+++ b/index.html
@@ -154,7 +154,6 @@
               "Jon Piesing",
               "John Riviello"
             ],
-            href: "https://www.cta.tech/resources-folder/standards/cta-5000-h/",
             date: "October 2025",
             publisher: "Consumer Technology Association",
             status: "CTA Specification"


### PR DESCRIPTION
This addresses the second part of #391 

This will be the last PR we'll merge prior to submitting for TWG review.

We won't know the URL for CTA-5000-H until WMAS2025 is approved & published from CTA, so we'll do a quick PR to add that after that happens before we publish the W3C CG Note


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/pull/399.html" title="Last updated on Sep 3, 2025, 3:28 PM UTC (c2503e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webmediaapi/399/7f827fe...c2503e3.html" title="Last updated on Sep 3, 2025, 3:28 PM UTC (c2503e3)">Diff</a>