### PR TITLE
Support table updates for WMAS2024+Errata and WMAS2025

### DIFF
--- a/wmas-support-table.html
+++ b/wmas-support-table.html
@@ -23,7 +23,7 @@
       }
       #cta-logo {
         float: right;
-        height: 44px;
+        height: 52px;
         margin-left: 1em;
       }
       h1 {
@@ -92,7 +92,7 @@
   <body>
     <div class="container">
       <section>
-        <img src="https://www.cta.tech/Content/Assets/img/ctalogo.svg" alt="CTA: Consumer Technology Association" id="cta-logo" />
+        <img src="https://cdn.cta.tech/cta/media/media/home/cta-logo.png" alt="CTA: Consumer Technology Association" id="cta-logo" />
         <h1>Web Media API Snapshot - Support by Year</h1>
         <p>This <em>non-normative</em> document attempts to visually capture which
           APIs are specified in <b>Section 3. Web Media APIs currently supported 
@@ -127,11 +127,13 @@
               <th><a href="https://www.w3.org/2022/12/webmediaapi.html"><abbr title="Web Media API Snapshot 2022">WMAS<br>2022</abbr></a></th>
               <th><a href="https://www.w3.org/2023/11/webmediaapi.html"><abbr title="Web Media API Snapshot 2023">WMAS<br>2023</abbr></a></th>
               <th><a href="https://www.w3.org/community/reports/webmediaapi/CG-FINAL-webmediaapi-20241016/"><abbr title="Web Media API Snapshot 2024">WMAS<br>2024</abbr></a></th>
+              <th><a href="https://www.w3.org/community/reports/webmediaapi/CG-FINAL-webmediaapi-20250411/"><abbr title="Web Media API Snapshot 2024 (April 2025 update with Errata)">WMAS 2024 + Errata</abbr></a></th>
+              <th><a href="https://www.w3.org/community/reports/webmediaapi/CG-FINAL-webmediaapi-20251022/"><abbr title="Web Media API Snapshot 2025">WMAS<br>2025</abbr></a></th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <th colspan="9" class="section">Core web specifications</th>
+              <th colspan="11" class="section">Core web specifications</th>
             </tr>
             <tr>
               <th>DOM</th>
@@ -143,6 +145,8 @@
               <td>21 June 2021</td>
               <td>20 June 2022</td>
               <td>19 June 2023</td>
+              <td>19 June 2023</td>
+              <td>17 June 2024</td>
             </tr>
             <tr>
               <th>ECMAScript</th>
@@ -154,6 +158,8 @@
               <td>2022 <abbr title="Exception(s) exist">!</abbr></td>
               <td>2023 <abbr title="Exception(s) exist">!</abbr></td>
               <td>2024 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>2024 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>2025 <abbr title="Exception(s) exist">!</abbr></td>
             </tr>
             <tr>
               <th>HTML</th>
@@ -165,11 +171,13 @@
               <td>17 January 2022 <abbr title="Exception(s) exist">!</abbr><abbr title="Note(s) exist">+</abbr></td>
               <td>16 January 2023 <abbr title="Exception(s) exist">!</abbr><abbr title="Note(s) exist">+</abbr></td>
               <td>15 January 2024 <abbr title="Exception(s) exist">!</abbr><abbr title="Note(s) exist">+</abbr></td>
+              <td>15 January 2024 <abbr title="Exception(s) exist">!</abbr><abbr title="Note(s) exist">+</abbr></td>
+              <td>15 January 2024 <abbr title="Exception(s) exist">!</abbr><abbr title="Note(s) exist">+</abbr></td>
             </tr>
           </tbody>
           <tbody>
             <tr>
-              <th colspan="9" class="section">CSS specifications</th>
+              <th colspan="11" class="section">CSS specifications</th>
             </tr>
             <tr>
               <th>CSS Snapshot</th>
@@ -181,9 +189,13 @@
               <td>2018 <abbr title="Note(s) exist">+</abbr></td>
               <td>2018 <abbr title="Note(s) exist">+</abbr></td>
               <td>2023</td>
+              <td>2023</td>
+              <td>2024</td>
             </tr>
             <tr>
               <th>Cascading Style Sheets</th>
+              <td>2.1</td>
+              <td>2.1</td>
               <td>2.1</td>
               <td>2.1</td>
               <td>2.1</td>
@@ -203,9 +215,13 @@
               <td>1</td>
               <td>1</td>
               <td>1</td>
+              <td>1</td>
+              <td>1</td>
             </tr>
             <tr>
               <th>CSS Animations</th>
+              <td>1</td>
+              <td>1</td>
               <td>1</td>
               <td>1</td>
               <td>1</td>
@@ -225,9 +241,13 @@
               <td>3</td>
               <td>3</td>
               <td>3</td>
+              <td>3</td>
+              <td>3</td>
             </tr>
             <tr>
               <th>CSS Basic User Interface Module</th>
+              <td>3</td>
+              <td>3</td>
               <td>3</td>
               <td>3</td>
               <td>3</td>
@@ -247,6 +267,8 @@
               <td></td>
               <td></td>
               <td>3</td>
+              <td>3</td>
+              <td>3</td>
             </tr>
             <tr>
               <th>CSS Cascading and Inheritance</th>
@@ -255,6 +277,8 @@
               <td>3</td>
               <td>3</td>
               <td>3</td>
+              <td>4</td>
+              <td>4</td>
               <td>4</td>
               <td>4</td>
               <td>4</td>
@@ -269,9 +293,13 @@
               <td>3</td>
               <td>4</td>
               <td>4</td>
+              <td>4</td>
+              <td>4</td>
             </tr>
             <tr>
               <th>CSS Conditional Rules Module</th>
+              <td>3</td>
+              <td>3</td>
               <td>3</td>
               <td>3</td>
               <td>3</td>
@@ -291,6 +319,8 @@
               <td>1</td>
               <td>1</td>
               <td>1</td>
+              <td>1</td>
+              <td>1</td>
             </tr>
             <tr>
               <th>CSS Counter Styles</th>
@@ -302,11 +332,15 @@
               <td></td>
               <td></td>
               <td>3</td>
+              <td>3</td>
+              <td>3</td>
             </tr>
             <tr>
               <th>CSS Custom Properties For Cascading Variables Module</th>
               <td></td>
               <td></td>
+              <td>1</td>
+              <td>1</td>
               <td>1</td>
               <td>1</td>
               <td>1</td>
@@ -324,9 +358,13 @@
               <td>1</td>
               <td>1</td>
               <td>1</td>
+              <td>1</td>
+              <td>1</td>
             </tr>
             <tr>
               <th>CSS Flexible Box Layout Module</th>
+              <td>1</td>
+              <td>1</td>
               <td>1</td>
               <td>1</td>
               <td>1</td>
@@ -346,9 +384,13 @@
               <td>3</td>
               <td>3</td>
               <td>3</td>
+              <td>3</td>
+              <td>3</td>
             </tr>
             <tr>
               <th>CSS Fonts Module</th>
+              <td>3</td>
+              <td>3</td>
               <td>3</td>
               <td>3</td>
               <td>3</td>
@@ -368,9 +410,13 @@
               <td>1</td>
               <td>1</td>
               <td>1</td>
+              <td>1</td>
+              <td>2</td>
             </tr>
             <tr>
               <th>CSS Images Module</th>
+              <td>3</td>
+              <td>3</td>
               <td>3</td>
               <td>3</td>
               <td>3</td>
@@ -390,9 +436,13 @@
               <td>1</td>
               <td>1</td>
               <td>1</td>
+              <td>1</td>
+              <td>1</td>
             </tr>
             <tr>
               <th>CSS Multi-column Layout Module</th>
+              <td>1</td>
+              <td>1</td>
               <td>1</td>
               <td>1</td>
               <td>1</td>
@@ -412,12 +462,16 @@
               <td>3</td>
               <td>3</td>
               <td>3</td>
+              <td>3</td>
+              <td>3</td>
             </tr>
             <tr>
               <th>CSS Scroll Snap Module</th>
               <td></td>
               <td></td>
               <td></td>
+              <td>1</td>
+              <td>1</td>
               <td>1</td>
               <td>1</td>
               <td>1</td>
@@ -434,9 +488,13 @@
               <td>1</td>
               <td>1</td>
               <td>1</td>
+              <td>1</td>
+              <td>1</td>
             </tr>
             <tr>
               <th>CSS Style Attributes</th>
+              <td>&check;</td>
+              <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
@@ -456,6 +514,8 @@
               <td>3</td>
               <td>3</td>
               <td>3</td>
+              <td>3</td>
+              <td>3</td>
             </tr>
             <tr>
               <th>CSS Text Decoration Module</th>
@@ -464,6 +524,8 @@
               <td></td>
               <td>3 <abbr title="Exception(s) exist">!</abbr></td>
               <td>3 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>3</td>
+              <td>3</td>
               <td>3</td>
               <td>3</td>
               <td>3</td>
@@ -478,9 +540,13 @@
               <td>1 <abbr title="Exception(s) exist">!</abbr></td>
               <td>1 <abbr title="Exception(s) exist">!</abbr></td>
               <td>1 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>1 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>1 <abbr title="Exception(s) exist">!</abbr></td>
             </tr>
             <tr>
               <th>CSS Transitions</th>
+              <td>1</td>
+              <td>1</td>
               <td>1</td>
               <td>1</td>
               <td>1</td>
@@ -500,12 +566,16 @@
               <td>3</td>
               <td>3</td>
               <td>3</td>
+              <td>3</td>
+              <td>3</td>
             </tr>
             <tr>
               <th>CSS Will Change Module</th>
               <td></td>
               <td></td>
               <td></td>
+              <td>1</td>
+              <td>1</td>
               <td>1</td>
               <td>1</td>
               <td>1</td>
@@ -522,10 +592,14 @@
               <td>3</td>
               <td>3</td>
               <td>3</td>
+              <td>3</td>
+              <td>3</td>
             </tr>
             <tr>
               <th>CSSOM View Module</th>
               <td></td>
+              <td>&check;</td>
+              <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
@@ -544,6 +618,8 @@
               <td>1</td>
               <td>1</td>
               <td>1</td>
+              <td>1</td>
+              <td>1</td>
             </tr>
             <tr>
               <th>Media Queries</th>
@@ -554,6 +630,8 @@
               <td>3</td>
               <td>3</td>
               <td>3</td>
+              <td>4 <abbr title="Note(s) exist">+</abbr></td>
+              <td>4 <abbr title="Note(s) exist">+</abbr></td>
               <td>4 <abbr title="Note(s) exist">+</abbr></td>
             </tr>
             <tr>
@@ -566,9 +644,13 @@
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
+              <td>&check;</td>
+              <td>&check;</td>
             </tr>
             <tr>
               <th>Selectors</th>
+              <td>3</td>
+              <td>3</td>
               <td>3</td>
               <td>3</td>
               <td>3</td>
@@ -588,14 +670,18 @@
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
+              <td>&check;</td>
+              <td>&check;</td>
             </tr>
           </tbody>
           <tbody>
             <tr>
-              <th colspan="9" class="section">Media specifications</th>
+              <th colspan="11" class="section">Media specifications</th>
             </tr>
             <tr>
               <th>Encrypted Media Extensions</th>
+              <td>1</td>
+              <td>1</td>
               <td>1</td>
               <td>1</td>
               <td>1</td>
@@ -615,6 +701,8 @@
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
+              <td>&check;</td>
+              <td>&check;</td>
             </tr>
             <tr>
               <th>Media Fragments URI</th>
@@ -626,9 +714,13 @@
               <td></td>
               <td>1.0 <abbr title="Note(s) exist">+</abbr></td>
               <td>1.0 <abbr title="Note(s) exist">+</abbr></td>
+              <td>1.0 <abbr title="Note(s) exist">+</abbr></td>
+              <td>1.0 <abbr title="Note(s) exist">+</abbr></td>
             </tr>
             <tr>
               <th>Media Source Extensions</th>
+              <td>1</td>
+              <td>1</td>
               <td>1</td>
               <td>1</td>
               <td>1</td>
@@ -648,6 +740,8 @@
               <td></td>
               <td></td>
               <td></td>
+              <td></td>
+              <td></td>
             </tr>
             <tr>
               <th>Web Audio API</th>
@@ -655,6 +749,8 @@
               <td>1.0 <abbr title="Exception(s) exist">!</abbr></td>
               <td>1.0 <abbr title="Exception(s) exist">!</abbr></td>
               <td>1.0 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>1.0</td>
+              <td>1.0</td>
               <td>1.0</td>
               <td>1.0</td>
               <td>1.0</td>
@@ -670,11 +766,13 @@
               <td>&check; <abbr title="Note(s) exist">+</abbr></td>
               <td>&check; <abbr title="Note(s) exist">+</abbr></td>
               <td>&check; <abbr title="Note(s) exist">+</abbr></td>
+              <td>&check; <abbr title="Note(s) exist">+</abbr></td>
+              <td>&check; <abbr title="Note(s) exist">+</abbr></td>
             </tr>
           </tbody>
           <tbody>
             <tr>
-              <th colspan="9" class="section">Graphics specifications</th>
+              <th colspan="11" class="section">Graphics specifications</th>
             </tr>
             <tr>
               <th>Fullscreen API Standard</th>
@@ -686,9 +784,13 @@
               <td>17 January 2022</td>
               <td>16 January 2023</td>
               <td>17 July 2023</td>
+              <td>17 July 2023</td>
+              <td>15 July 2024</td>
             </tr>
             <tr>
               <th>Graphics Interchange Format</th>
+              <td>&check;</td>
+              <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
@@ -708,9 +810,13 @@
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
+              <td><i>(via HTML)</i></td>
+              <td><i>(via HTML)</i></td>
             </tr>
             <tr>
               <th>JPEG File Interchange Format</th>
+              <td>&check;</td>
+              <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
@@ -730,6 +836,8 @@
               <td>2</td>
               <td>2</td>
               <td>2</td>
+              <td>2</td>
+              <td>2</td>
             </tr>
             <tr>
               <th>WebGL Specification</th>
@@ -741,14 +849,18 @@
               <td>1.03</td>
               <td>1.03</td>
               <td>1.03</td>
+              <td>1.03</td>
+              <td>1.03</td>
             </tr>
           </tbody>
           <tbody>
             <tr>
-              <th colspan="9" class="section">Font specifications</th>
+              <th colspan="11" class="section">Font specifications</th>
             </tr>
             <tr>
               <th>Open Font Format</th>
+              <td>&check;</td>
+              <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
@@ -768,11 +880,13 @@
               <td>1</td>
               <td>1</td>
               <td>1</td>
+              <td>1</td>
+              <td>1</td>
             </tr>
           </tbody>
           <tbody>
             <tr>
-              <th colspan="9" class="section">Networking specifications</th>
+              <th colspan="11" class="section">Networking specifications</th>
             </tr>
             <tr>
               <th>Fetch</th>
@@ -784,6 +898,8 @@
               <td>19 December 2021</td>
               <td>19 December 2022</td>
               <td>18 December 2023 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>18 December 2023 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>16 December 2024 <abbr title="Exception(s) exist">!</abbr></td>
             </tr>
             <tr>
               <th>WebSockets</th>
@@ -794,6 +910,8 @@
               <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>
               <td>19 September 2022</td>
+              <td>18 September 2023</td>
+              <td>18 September 2023</td>
               <td>18 September 2023</td>
             </tr>
             <tr>
@@ -806,11 +924,13 @@
               <td>21 February 2022</td>
               <td>20 February 2023</td>
               <td>19 February 2024</td>
+              <td>19 February 2024</td>
+              <td>19 February 2024</td>
             </tr>
           </tbody>
           <tbody>
             <tr>
-              <th colspan="9" class="section">Security specifications</th>
+              <th colspan="11" class="section">Security specifications</th>
             </tr>
             <tr>
               <th>Content Security Policy</th>
@@ -822,6 +942,21 @@
               <td>2</td>
               <td>2</td>
               <td>2</td>
+              <td>2</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <th>HTTP Strict Transport Security (HSTS)</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td>&check;</td>
+              <td>&check;</td>
             </tr>
             <tr>
               <th>Referrer Policy</th>
@@ -833,11 +968,15 @@
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
+              <td>&check;</td>
+              <td>&check;</td>
             </tr>
             <tr>
               <th>Subresource Integrity</th>
               <td></td>
               <td></td>
+              <td>&check;</td>
+              <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
@@ -855,11 +994,15 @@
               <td>1.2 &amp; 1.3</td>
               <td>1.2 &amp; 1.3</td>
               <td>1.2 &amp; 1.3</td>
+              <td>1.2 &amp; 1.3</td>
+              <td>1.2 &amp; 1.3</td>
             </tr>
             <tr>
               <th>Upgrade Insecure Requests</th>
               <td></td>
               <td></td>
+              <td>&check;</td>
+              <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
@@ -877,17 +1020,21 @@
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
+              <td>&check;</td>
+              <td>&check;</td>
             </tr>
           </tbody>
           <tbody>
             <tr>
-              <th colspan="9" class="section">Web Performance specifications</th>
+              <th colspan="11" class="section">Web Performance specifications</th>
             </tr>
             <tr>
               <th>Beacon</th>
               <td></td>
               <td></td>
               <td></td>
+              <td>&check;</td>
+              <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
@@ -904,12 +1051,16 @@
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
+              <td>&check;</td>
+              <td>&check;</td>
             </tr>
             <tr>
               <th>Navigation Timing</th>
               <td></td>
               <td></td>
               <td></td>
+              <td>&check;</td>
+              <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
@@ -926,12 +1077,16 @@
               <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>
+              <td><i>(via HTML)</i></td>
+              <td><i>(via HTML)</i></td>
             </tr>
             <tr>
               <th>Performance Timeline</th>
               <td></td>
               <td></td>
               <td></td>
+              <td>&check;</td>
+              <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
@@ -948,6 +1103,8 @@
               <td>1</td>
               <td>1</td>
               <td>1</td>
+              <td>1</td>
+              <td>19 July 2022</td>
             </tr>
             <tr>
               <th>User Timing</th>
@@ -959,15 +1116,19 @@
               <td>2</td>
               <td>2</td>
               <td>2</td>
+              <td>2</td>
+              <td>2</td>
             </tr>
           </tbody>
           <tbody>
             <tr>
-              <th colspan="9" class="section">Other web specifications</th>
+              <th colspan="11" class="section">Other web specifications</th>
             </tr>
             <tr>
               <th>Channel messaging</th>
               <td>&check;</td>
+              <td><i>(via HTML)</i></td>
+              <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>
@@ -986,12 +1147,16 @@
               <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>
+              <td><i>(via HTML)</i></td>
+              <td><i>(via HTML)</i></td>
             </tr>
             <tr>
               <th>File API</th>
               <td></td>
               <td>&check; <abbr title="Exception(s) exist">!</abbr></td>
               <td>&check; <abbr title="Exception(s) exist">!</abbr></td>
+              <td>&check;</td>
+              <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
@@ -1008,21 +1173,27 @@
               <td>2.0</td>
               <td>2.0</td>
               <td>2.0</td>
+              <td>2.0</td>
+              <td>2.0</td>
             </tr>
             <tr>
               <th>Notifications API</th>
+              <td>22 October 2015</td>
               <td>&check;</td>
-              <td>&check;</td>
-              <td>&check;</td>
-              <td>&check; <abbr title="Exception(s) exist">!</abbr></td>
-              <td>&check; <abbr title="Exception(s) exist">!</abbr></td>
-              <td>&check; <abbr title="Exception(s) exist">!</abbr></td>
-              <td>&check; <abbr title="Exception(s) exist">!</abbr></td>
-              <td>&check; <abbr title="Exception(s) exist">!</abbr></td>
+              <td>23 January 2019</td>
+              <td>29 January 2020 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>18 January 2021 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>17 January 2022 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>16 January 2023 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>17 July 2023 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>17 July 2023 <abbr title="Exception(s) exist">!</abbr></td>
+              <td>20 January 2025 <abbr title="Exception(s) exist">!</abbr></td>
             </tr>
             <tr>
               <th>Service Workers</th>
               <td></td>
+              <td>1</td>
+              <td>1</td>
               <td>1</td>
               <td>1</td>
               <td>1</td>
@@ -1041,6 +1212,8 @@
               <td>&check;</td>
               <td>&check;</td>
               <td>&check;</td>
+              <td>&check;</td>
+              <td>&check;</td>
             </tr>
             <tr>
               <th>Web Storage</th>
@@ -1052,10 +1225,14 @@
               <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>
+              <td><i>(via HTML)</i></td>
+              <td><i>(via HTML)</i></td>
             </tr>
             <tr>
               <th>Web Workers</th>
               <td>&check; <abbr title="Exception(s) exist">!</abbr></td>
+              <td><i>(via HTML)</i></td>
+              <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>
               <td><i>(via HTML)</i></td>


### PR DESCRIPTION
This closes #381 & #400

Also replaced the SVG version of the CTA logo with a PNG since the URL of the SVG is returning a 404 error