### PR TITLE
WHATWG updates for 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,8 +67,8 @@
             authors: [
               "Anne van Kesteren"
             ],
-            href: "https://fetch.spec.whatwg.org/review-drafts/2024-12/",
-            date: "16 December 2024",
+            href: "https://fetch.spec.whatwg.org/review-drafts/2025-12/",
+            date: "15 December 2025",
             status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
@@ -77,8 +77,8 @@
             authors: [
               "Philip Jägenstedt"
             ],
-            href: "https://fullscreen.spec.whatwg.org/review-drafts/2024-07/",
-            date: "15 July 2024",
+            href: "https://fullscreen.spec.whatwg.org/review-drafts/2026-01/",
+            date: "20 January 2026",
             status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
@@ -101,8 +101,8 @@
             authors: [
               "Anne van Kesteren"
             ],
-            href: "https://notifications.spec.whatwg.org/review-drafts/2025-01/",
-            date: "20 January 2025",
+            href: "https://notifications.spec.whatwg.org/review-drafts/2026-01/",
+            date: "20 January 2026",
             status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
@@ -121,8 +121,8 @@
             authors: [
               "Anne van Kesteren"
             ],
-            href: "https://xhr.spec.whatwg.org/review-drafts/2024-02/",
-            date: "19 February 2024",
+            href: "https://xhr.spec.whatwg.org/review-drafts/2025-08/",
+            date: "18 August 2025",
             status: "Review Draft (use this version or later)",
             publisher: "WHATWG"
           },
@@ -257,8 +257,6 @@
               <li>Exceptions:
                 <ul>
                   <li><a href="https://html.spec.whatwg.org/review-drafts/2024-01/#css-module-script">CSS module scripts</a> are not yet widely supported.</li>
-                  <li>The <a href="https://html.spec.whatwg.org/review-drafts/2024-01/#attr-hidden-until-found-state"><code>hidden=until-found</code></a> HTML attribute and the <a href="https://html.spec.whatwg.org/review-drafts/2024-01/#event-beforematch"><code>beforematch</code></a> event are not yet widely supported.</li>
-                  <li>The <a href="https://html.spec.whatwg.org/review-drafts/2024-01/#navigation-api">Navigation API</a> is not yet widely supported.</li>
                   <li>The <a href="https://html.spec.whatwg.org/review-drafts/2024-01/#close-requests-and-close-watchers">CloseWatcher API</a> is not yet widely supported.</li>
                   <li>The <a href="https://html.spec.whatwg.org/review-drafts/2024-01/#common-input-element-apis:htmlselectelement"><code>showPicker()</code> support for <code>&lt;select&gt;</code> elements</a> is not yet widely supported.</li>
                 </ul>
@@ -366,10 +364,11 @@
             <ul>
               <li>Exceptions:
                 <ul>
-                  <li>The <a href="https://fetch.spec.whatwg.org/review-drafts/2024-12/#sec-purpose-header"><code>Sec-Purpose: prefetch</code> header</a> is not yet widely supported.</li>
-                  <li>The <a href="https://fetch.spec.whatwg.org/review-drafts/2024-12/#concept-request-destination"><code>"json"</code> destination for JSON modules</a> is not yet widely supported.</li>
-                  <li><a href="https://fetch.spec.whatwg.org/review-drafts/2024-12/#body-mixin">Setting the proper realm of the result of <code>Response arrayBuffer()</code></a> is not yet widely supported.</li>
-                  <li><a href="https://fetch.spec.whatwg.org/review-drafts/2024-12/#scheme-fetch">Partitioning <code>Blob URL</code> fetches by storage key</a> is not yet widely supported.</li>
+                  <li>The <a href="https://fetch.spec.whatwg.org/review-drafts/2025-12/#sec-purpose-header"><code>Sec-Purpose: prefetch</code> header</a> is not yet widely supported.</li>
+                  <li>The <a href="https://fetch.spec.whatwg.org/review-drafts/2025-12/#concept-request-destination"><code>"json"</code> destination for JSON modules</a> is not yet widely supported.</li>
+                  <li><a href="https://fetch.spec.whatwg.org/review-drafts/2025-12/#body-mixin">Setting the proper realm of the result of <code>Response arrayBuffer()</code></a> is not yet widely supported.</li>
+                  <li><a href="https://fetch.spec.whatwg.org/review-drafts/2025-12/#scheme-fetch">Partitioning <code>Blob URL</code> fetches by storage key</a> is not yet widely supported.</li>
+                  <li><a href="https://fetch.spec.whatwg.org/review-drafts/2025-12/#deferred-fetch">Deferred fetching via <code>fetchLater()</code></a> is not yet widely supported.</li>
                 </ul>
             </ul>
           </li>


### PR DESCRIPTION
- More recent review drafts of Fetch, Fullscreen, Notifications API, XHR
- Updated exceptions for HTML and Fetch

This addresses #409


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-cg/webmediaapi/pull/420.html" title="Last updated on Aug 3, 2026, 7:41 PM UTC (42db526)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-cg/webmediaapi/420/97f2551...42db526.html" title="Last updated on Aug 3, 2026, 7:41 PM UTC (42db526)">Diff</a>