### PR TITLE
Removing localBiblio entry for WMAS2025 binding

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,17 +136,6 @@
             date: "19 July 2022",
             status: "Working Draft (use this version or later)",
             publisher: "W3C"
-          },
-          "CTA-5000-H": {
-            title: "Web Media API Snapshot 2025 CTA-5000-H",
-            authors: [
-              "Jon Piesing",
-              "John Riviello"
-            ],
-            href: "https://www.cta.tech/standards/web-application-video-ecosystem-web-media-api-snapshot-2025/",
-            date: "October 2025",
-            publisher: "Consumer Technology Association",
-            status: "CTA Specification"
           }
         }
       };


### PR DESCRIPTION
since it's now in SpecRef

This addresses the first part of #413


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-cg/webmediaapi/pull/423.html" title="Last updated on Aug 4, 2026, 4:26 PM UTC (1146ee3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-cg/webmediaapi/423/97f2551...1146ee3.html" title="Last updated on Aug 4, 2026, 4:26 PM UTC (1146ee3)">Diff</a>