### PR TITLE
Adding 2026 binding

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,16 @@
             date: "19 July 2022",
             status: "Working Draft (use this version or later)",
             publisher: "W3C"
+          },
+          "CTA-5000-I": {
+            title: "Web Media API Snapshot 2026 CTA-5000-I",
+            authors: [
+              "Jon Piesing",
+              "John Riviello"
+            ],
+            date: "October 2026",
+            publisher: "Consumer Technology Association",
+            status: "CTA Specification"
           }
         }
       };
@@ -518,6 +528,10 @@
           <tr>
             <td>urn:cta:wave:appinformation:standardversion:cta5000h:2025</td>
             <td>Web Media API Snapshot 2025 CTA-5000-H [[CTA-5000-H]]</td>
+          </tr>
+          <tr>
+            <td>urn:cta:wave:appinformation:standardversion:cta5000i:2026</td>
+            <td>Web Media API Snapshot 2026 CTA-5000-I [[CTA-5000-I]]</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
This addresses part of #391 

This will be the last PR we'll merge prior to submitting for TWG review.

We won't know the URL for CTA-5000-I until WMAS2026 is approved & published from CTA, so we'll do a quick PR to add that after that happens before we publish the W3C CG Note